### PR TITLE
Refactor tasks.py and improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: python
 python:
   - "2.7"
 
+services:
+  - mongodb
+
 before_install:
   - pip install codecov
 

--- a/edx_shopify/tasks.py
+++ b/edx_shopify/tasks.py
@@ -1,4 +1,5 @@
 from celery import Task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 
 from .models import Order
@@ -7,38 +8,28 @@ from .utils import process_order
 logger = get_task_logger(__name__)
 
 
-class ProcessOrder(Task):
-    """Process a newly received order, and enroll learners in courses
-    using their email address.
+class OrderTask(Task):
+    """Process a newly received order.
 
     On failure, store the order in an ERROR state.
     """
 
     def __init__(self):
         """Set up an order as an instance member, so we can manipulate it both
-        from run() and from on_failure().
+        from task methods and from handlers.
         """
 
         self.order = None
 
-    def run(self, data):
-        """Parse input data for line items, and create enrollments.
-
-        On any error, raise the exception in order to be handled by
-        on_failure().
-        """
-
-        logger.debug('Processing order data: %s' % data)
-        self.order = Order.objects.get(id=data['id'])
-
-        process_order(self.order, data, logger)
-        logger.error('Successfully processed '
-                     'order %s' % self.order.id)
+    def on_success(self, retval, task_id, args, kwargs):
+        "Success handler: log successful order processing."
+        logger.info('Successfully processed '
+                    'order %s' % self.order.id)
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
-        """Handle the run() method having raised an exception: log an
-        exception stack trace and a prose message, save the order with
-        an ERROR status.
+        """Failure handler: log an exception stack trace and a prose message,
+        then save the order with an ERROR status.
+
         """
 
         logger.error(exc, exc_info=True)
@@ -48,3 +39,20 @@ class ProcessOrder(Task):
                                        task_id))
         self.order.status = Order.ERROR
         self.order.save()
+
+
+@shared_task(bind=True,
+             max_retries=3,
+             soft_time_limit=5,
+             base=OrderTask)
+def process(self, data):
+    """Parse input data for line items, and create enrollments.
+
+    On any error, raise the exception in order to be handled by
+    on_failure().
+    """
+
+    logger.debug('Processing order data: %s' % data)
+    self.order = Order.objects.get(id=data['id'])
+
+    process_order(self.order, data, logger)

--- a/edx_shopify/tasks.py
+++ b/edx_shopify/tasks.py
@@ -45,7 +45,7 @@ class OrderTask(Task):
              max_retries=3,
              soft_time_limit=5,
              base=OrderTask)
-def process(self, data):
+def process(self, data, send_email=False):
     """Parse input data for line items, and create enrollments.
 
     On any error, raise the exception in order to be handled by
@@ -55,4 +55,4 @@ def process(self, data):
     logger.debug('Processing order data: %s' % data)
     self.order = Order.objects.get(id=data['id'])
 
-    process_order(self.order, data, logger)
+    process_order(self.order, data, send_email, logger)

--- a/edx_shopify/utils.py
+++ b/edx_shopify/utils.py
@@ -32,7 +32,9 @@ def record_order(data):
     )
 
 
-def auto_enroll_email(course_id, email):
+def auto_enroll_email(course_id,
+                      email,
+                      email_students=False):
     """
     Auto-enroll email in course.
 
@@ -43,17 +45,27 @@ def auto_enroll_email(course_id, email):
 
     course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     course = get_course_by_id(course_id)
-    email_params = get_email_params(course, True, secure=True)
 
-    # Try to find out what language to send the email in.
-    user = None
+    # If we want to notify the newly enrolled student by email, fetch
+    # the required parameters
+    email_params = None
     language = None
-    try:
-        user = User.objects.get(email=email)
-    except User.DoesNotExist:
-        pass
-    else:
-        language = get_user_email_language(user)
+    if email_students:
+        email_params = get_email_params(course, True, secure=True)
+
+        # Try to find out what language to send the email in.
+        user = None
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            pass
+        else:
+            language = get_user_email_language(user)
 
     # Enroll the email
-    enroll_email(course_id, email, True, True, email_params, language=language)
+    enroll_email(course_id,
+                 email,
+                 auto_enroll=True,
+                 email_students=email_students,
+                 email_params=email_params,
+                 language=language)

--- a/edx_shopify/utils.py
+++ b/edx_shopify/utils.py
@@ -38,12 +38,12 @@ def auto_enroll_email(course_id, email):
 
     Based on lms.djangoapps.instructor.views.api.students_update_enrollment()
     """
+    # Raises ValidationError if invalid
+    validate_email(email)
+
     course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     course = get_course_by_id(course_id)
     email_params = get_email_params(course, True, secure=True)
-
-    # Raises ValidationError if invalid
-    validate_email(email)
 
     # Try to find out what language to send the email in.
     user = None

--- a/edx_shopify/utils.py
+++ b/edx_shopify/utils.py
@@ -33,7 +33,7 @@ def record_order(data):
     )
 
 
-def process_order(order, data, logger=None):
+def process_order(order, data, send_email=False, logger=None):
     if not logger:
         logger = logging
 
@@ -91,7 +91,7 @@ def process_line_item(order, item):
 
 def auto_enroll_email(course_id,
                       email,
-                      email_students=False):
+                      send_email=False):
     """
     Auto-enroll email in course.
 
@@ -107,7 +107,7 @@ def auto_enroll_email(course_id,
     # the required parameters
     email_params = None
     language = None
-    if email_students:
+    if send_email:
         email_params = get_email_params(course, True, secure=True)
 
         # Try to find out what language to send the email in.
@@ -120,9 +120,9 @@ def auto_enroll_email(course_id,
             language = get_user_email_language(user)
 
     # Enroll the email
-    enroll_email(course_id,
+    enroll_email(locator,
                  email,
                  auto_enroll=True,
-                 email_students=email_students,
+                 email_students=send_email,
                  email_params=email_params,
                  language=language)

--- a/edx_shopify/utils.py
+++ b/edx_shopify/utils.py
@@ -57,6 +57,8 @@ def process_order(order, data, send_email=False, logger=None):
     order.status = Order.PROCESSED
     order.save()
 
+    return order
+
 
 def process_line_item(order, item):
     """Process a line item of an order.
@@ -87,6 +89,8 @@ def process_line_item(order, item):
     # Mark the item as processed
     order_item.status = OrderItem.PROCESSED
     order_item.save()
+
+    return order_item
 
 
 def auto_enroll_email(course_id,

--- a/edx_shopify/utils.py
+++ b/edx_shopify/utils.py
@@ -5,7 +5,7 @@ import logging
 
 from django.core.validators import validate_email
 from django.contrib.auth.models import User
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 from courseware.courses import get_course_by_id
 from lms.djangoapps.instructor.enrollment import (
     get_user_email_language,
@@ -100,8 +100,8 @@ def auto_enroll_email(course_id,
     # Raises ValidationError if invalid
     validate_email(email)
 
-    course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
-    course = get_course_by_id(course_id)
+    locator = CourseLocator.from_string(course_id)
+    course = get_course_by_id(locator)
 
     # If we want to notify the newly enrolled student by email, fetch
     # the required parameters

--- a/edx_shopify/utils.py
+++ b/edx_shopify/utils.py
@@ -12,11 +12,24 @@ from lms.djangoapps.instructor.enrollment import (
     get_email_params
 )
 
+from .models import Order
+
 
 def hmac_is_valid(key, msg, hmac_to_verify):
     hash = hmac.new(str(key), str(msg), hashlib.sha256)
     hmac_calculated = base64.b64encode(hash.digest())
     return hmac.compare_digest(hmac_calculated, hmac_to_verify)
+
+
+def record_order(data):
+    return Order.objects.get_or_create(
+        id=data['id'],
+        defaults={
+            'email': data['customer']['email'],
+            'first_name': data['customer']['first_name'],
+            'last_name': data['customer']['last_name']
+        }
+    )
 
 
 def auto_enroll_email(course_id, email):

--- a/edx_shopify/utils.py
+++ b/edx_shopify/utils.py
@@ -95,7 +95,7 @@ def process_line_item(order, item):
 
 def auto_enroll_email(course_id,
                       email,
-                      send_email=False):
+                      send_email=True):
     """
     Auto-enroll email in course.
 

--- a/edx_shopify/views.py
+++ b/edx_shopify/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.http import require_POST
 
 from .utils import hmac_is_valid, record_order
 from .models import Order
-from .tasks import ProcessOrder
+from .tasks import process
 
 
 @csrf_exempt
@@ -33,6 +33,6 @@ def order_create(request):
 
     # Process order
     if order.status == Order.UNPROCESSED:
-        ProcessOrder().apply_async(args=(data,))
+        process.delay(data)
 
     return HttpResponse(status=200)

--- a/edx_shopify/views.py
+++ b/edx_shopify/views.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from .utils import hmac_is_valid
+from .utils import hmac_is_valid, record_order
 from .models import Order
 from .tasks import ProcessOrder
 
@@ -29,14 +29,7 @@ def order_create(request):
         return HttpResponse(status=403)
 
     # Record order
-    order, created = Order.objects.get_or_create(
-        id=data['id'],
-        defaults={
-            'email': data['customer']['email'],
-            'first_name': data['customer']['first_name'],
-            'last_name': data['customer']['last_name']
-        }
-    )
+    order, created = record_order(data)
 
     # Process order
     if order.status == Order.UNPROCESSED:

--- a/edx_shopify/views.py
+++ b/edx_shopify/views.py
@@ -31,8 +31,14 @@ def order_create(request):
     # Record order
     order, created = record_order(data)
 
+    send_email = True
+    try:
+        send_email = conf['send_email']
+    except KeyError:
+        pass
+
     # Process order
     if order.status == Order.UNPROCESSED:
-        process.delay(data)
+        process.delay(data, send_email)
 
     return HttpResponse(status=200)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -51,3 +51,6 @@ git+https://github.com/edx/edx-submissions.git@2.0.0#egg=edx-submissions==2.0.0
 django-waffle==0.11.1
 edx-celeryutils==0.1.3
 django-ratelimit-backend==1.0
+factory_boy==2.8.1
+pymongo==2.9.1
+git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0

--- a/runtests.py
+++ b/runtests.py
@@ -3,6 +3,24 @@ import sys
 import os
 from coverage import coverage
 from optparse import OptionParser
+import contracts
+
+contracts.disable_all()
+
+# Add Open edX common and LMS Django apps to PYTHONPATH
+sys.path.append(os.path.join(os.path.dirname(__file__),
+                             'edx-platform'))
+for directory in ['common', 'lms']:
+    sys.path.append(os.path.join(os.path.dirname(__file__),
+                                 'edx-platform',
+                                 directory,
+                                 'djangoapps'))
+for lib in ['xmodule', 'dogstats', 'capa', 'calc', 'chem']:
+    sys.path.append(os.path.join(os.path.dirname(__file__),
+                                 'edx-platform',
+                                 'common',
+                                 'lib',
+                                 lib))
 
 # This envar must be set before importing NoseTestSuiteRunner,
 # silence flake8 E402 ("module level import not at top of file").
@@ -13,21 +31,6 @@ from django_nose import NoseTestSuiteRunner  # noqa: E402
 def run_tests(*test_args):
     if not test_args:
         test_args = ['tests']
-
-    # Add Open edX common and LMS Django apps to PYTHONPATH
-    sys.path.append(os.path.join(os.path.dirname(__file__),
-                                 'edx-platform'))
-    for directory in ['common', 'lms']:
-        sys.path.append(os.path.join(os.path.dirname(__file__),
-                                     'edx-platform',
-                                     directory,
-                                     'djangoapps'))
-    for lib in ['xmodule', 'dogstats', 'capa', 'calc', 'chem']:
-        sys.path.append(os.path.join(os.path.dirname(__file__),
-                                     'edx-platform',
-                                     'common',
-                                     'lib',
-                                     lib))
 
     # Run tests
     test_runner = NoseTestSuiteRunner(verbosity=1)

--- a/test_settings.py
+++ b/test_settings.py
@@ -11,13 +11,14 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 """
 import contracts
 import tempfile
+import os
+
+from uuid import uuid4
 from xmodule.modulestore import prefer_xmodules
 from xmodule.x_module import XModuleMixin
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.modulestore.edit_info import EditInfoMixin
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
-
-
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
@@ -119,7 +120,18 @@ RECALCULATE_GRADES_ROUTING_KEY = LOW_PRIORITY_QUEUE
 COMMON_TEST_DATA_ROOT = 'tmp'
 DATA_DIR = tempfile.mkdtemp()
 
-CONTENTSTORE = None
+THIS_UUID = uuid4().hex[:5]
+MONGO_PORT_NUM = int(os.environ.get('EDXAPP_TEST_MONGO_PORT', '27017'))
+MONGO_HOST = os.environ.get('EDXAPP_TEST_MONGO_HOST', 'localhost')
+CONTENTSTORE = {
+    'ENGINE': 'xmodule.contentstore.mongo.MongoContentStore',
+    'DOC_STORE_CONFIG': {
+        'host': MONGO_HOST,
+        'db': 'test_xcontent_{}'.format(THIS_UUID),
+        'port': MONGO_PORT_NUM,
+    }
+}
+
 DOC_STORE_CONFIG = {
     'host': 'localhost',
     'db': 'xmodule',
@@ -159,10 +171,12 @@ MODULESTORE = {
     }
 }
 
-# These are the Mixins that should be added to every XBlock.
-# This should be moved into an XBlock Runtime/Application object
-# once the responsibility of XBlock creation is moved out of modulestore - cpennington
-XBLOCK_MIXINS = (LmsBlockMixin, InheritanceMixin, XModuleMixin, EditInfoMixin)
+# These are the Mixins that should be added to every XBlock.  This
+# should be moved into an XBlock Runtime/Application object once the
+# responsibility of XBlock creation is moved out of modulestore -
+# cpennington
+XBLOCK_MIXINS = (LmsBlockMixin, InheritanceMixin,
+                 XModuleMixin, EditInfoMixin)
 
 # Allow any XBlock in the LMS
 XBLOCK_SELECT_FUNCTION = prefer_xmodules
@@ -204,11 +218,11 @@ EVENT_TRACKING_BACKENDS = {
         'ENGINE': 'eventtracking.backends.routing.RoutingBackend',
         'OPTIONS': {
             'backends': {
-                'segment': {'ENGINE': 'eventtracking.backends.segment.SegmentBackend'}
+                'segment': {'ENGINE': 'eventtracking.backends.segment.SegmentBackend'}  # noqa: E501
             },
             'processors': [
                 {
-                    'ENGINE': 'eventtracking.processors.whitelist.NameWhitelistProcessor',
+                    'ENGINE': 'eventtracking.processors.whitelist.NameWhitelistProcessor',  # noqa: E501
                     'OPTIONS': {
                         'whitelist': []
                     }

--- a/test_settings.py
+++ b/test_settings.py
@@ -236,4 +236,8 @@ EVENT_TRACKING_BACKENDS = {
 }
 EVENT_TRACKING_PROCESSORS = []
 
+SITE_NAME = 'localhost:8000'
+
+EDX_ROOT_URL = ''
+
 contracts.disable_all()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+
+from django.test import TestCase
+
+
+class JsonPayloadTestCase(TestCase):
+
+    def setUp(self):
+        # Grab an example payload and make it available to test
+        # methods as a raw string and as a JSON dictionary.
+        payload_file = os.path.join(os.path.dirname(__file__),
+                                    'post.json')
+        self.raw_payload = open(payload_file, 'r').read()
+        self.json_payload = json.loads(self.raw_payload)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,13 @@ import os
 
 from django.test import TestCase
 
+from opaque_keys.edx.locator import CourseLocator, BlockUsageLocator
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
 
 class JsonPayloadTestCase(TestCase):
 
@@ -14,3 +21,36 @@ class JsonPayloadTestCase(TestCase):
                                     'post.json')
         self.raw_payload = open(payload_file, 'r').read()
         self.json_payload = json.loads(self.raw_payload)
+
+
+class MockCourseTestCase(TestCase):
+
+    def setUp(self):
+        # Set up a mock course
+        course_id_string = 'course-v1:org+course+run1'
+        cl = CourseLocator.from_string(course_id_string)
+        bul = BlockUsageLocator(cl, u'course', u'course')
+        course = Mock()
+        course.id = cl
+        course.system = Mock()
+        course.scope_ids = Mock()
+        course.scope_id.user_id = None
+        course.scope_ids.block_type = u'course'
+        course.scope_ids.def_id = bul
+        course.scope_ids.usage_id = bul
+        course.location = bul
+        course.display_name = u'Course - Run 1'
+
+        self.course_id_string = course_id_string
+        self.cl = cl
+        self.course = course
+
+        email_params = {'registration_url': u'https://localhost:8000/register',  # noqa: E501
+                        'course_about_url': u'https://localhost:8000/courses/course-v1:org+course+run1/about',  # noqa: E501
+                        'site_name': 'localhost:8000',
+                        'course': course,
+                        'is_shib_course': None,
+                        'display_name': u'Course - Run 1',
+                        'auto_enroll': True,
+                        'course_url': u'https://localhost:8000/courses/course-v1:org+course+run1/'}  # noqa: E501
+        self.email_params = email_params

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+import json
+
+from django.http import Http404
+
+from edx_shopify.models import Order
+from edx_shopify.tasks import process
+from edx_shopify.utils import record_order
+
+from . import JsonPayloadTestCase
+
+
+class ProcessOrderTest(JsonPayloadTestCase):
+
+    def test_invalid_sku(self):
+        fixup_payload = self.raw_payload.replace("course-v1:org+course+run1",
+                                                 "course-v1:org+nosuchcourse+run1")  # noqa: E501
+        fixup_json_payload = json.loads(fixup_payload)
+        order, created = record_order(fixup_json_payload)
+
+        result = None
+        with self.assertRaises(Http404):
+            result = process.delay(fixup_json_payload)
+            result.get(5)
+
+        self.assertEqual(result.state, 'FAILURE')
+
+        # Even with the exception raised, it's the task failure
+        # handler's job to set the status to ERROR. Given the async
+        # nature of the task, though, the object reference doesn't
+        # learn of the update until we refresh from the database.
+        order.refresh_from_db()
+        self.assertEqual(order.status, Order.ERROR)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
-from edx_shopify.utils import hmac_is_valid
+from edx_shopify.utils import hmac_is_valid, auto_enroll_email
 from django.test import TestCase
+from django.http import Http404
 
 
 class SignatureVerificationTest(TestCase):
@@ -22,3 +23,17 @@ class SignatureVerificationTest(TestCase):
 
         for triplet in incorrect_hmac:
             self.assertFalse(hmac_is_valid(*triplet))
+
+
+class EmailEnrollmentTest(TestCase):
+
+    def test_enrollment_failure(self):
+        # Enrolling in a non-existent course (or run) should fail, no
+        # matter whether the user exists or not
+        with self.assertRaises(Http404):
+            auto_enroll_email('course-v1:org+nosuchcourse+run1',
+                              'learner@example.com')
+            auto_enroll_email('course-v1:org+course+nosuchrun',
+                              'learner@example.com')
+            auto_enroll_email('course-v1:org+nosuchcourse+run1',
+                              'johndoe@example.com')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
-from edx_shopify.utils import hmac_is_valid, auto_enroll_email
+from edx_shopify.utils import hmac_is_valid, record_order, auto_enroll_email
 from django.test import TestCase
 from django.http import Http404
+
+from . import JsonPayloadTestCase
 
 
 class SignatureVerificationTest(TestCase):
@@ -23,6 +25,21 @@ class SignatureVerificationTest(TestCase):
 
         for triplet in incorrect_hmac:
             self.assertFalse(hmac_is_valid(*triplet))
+
+
+class RecordOrderTest(JsonPayloadTestCase):
+
+    def test_record_order(self):
+        # Make sure the order gets created, and that its ID matches
+        # that in the payload
+        order1, created1 = record_order(self.json_payload)
+        self.assertTrue(created1)
+        self.assertEqual(order1.id, self.json_payload['id'])
+        # Try to create the order again, make sure we get a reference
+        # instead
+        order2, created2 = record_order(self.json_payload)
+        self.assertFalse(created2)
+        self.assertEqual(order1, order2)
 
 
 class EmailEnrollmentTest(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,6 @@ from django.test import TestCase
 from django.http import Http404
 from django.core.exceptions import ValidationError
 
-from opaque_keys.edx.locator import CourseLocator, BlockUsageLocator
-
 # We need this in order to mock.patch get_course_by_id
 from edx_shopify import utils
 
@@ -16,7 +14,7 @@ from edx_shopify.utils import process_order, process_line_item
 
 from edx_shopify.models import Order
 
-from . import JsonPayloadTestCase
+from . import JsonPayloadTestCase, MockCourseTestCase
 
 try:
     from unittest.mock import Mock, patch
@@ -80,7 +78,7 @@ class ProcessOrderTest(JsonPayloadTestCase):
         self.assertEqual(order.status, Order.PROCESSING)
 
 
-class ProcessLineItemTest(TestCase):
+class ProcessLineItemTest(MockCourseTestCase):
 
     def test_invalid_line_item(self):
         order = Order()
@@ -116,37 +114,7 @@ class ProcessLineItemTest(TestCase):
                 process_line_item(order, line_item)
 
 
-class EmailEnrollmentTest(TestCase):
-
-    def setUp(self):
-        # Set up a mock course
-        course_id_string = 'course-v1:org+course+run1'
-        cl = CourseLocator.from_string(course_id_string)
-        bul = BlockUsageLocator(cl, u'course', u'course')
-        course = Mock()
-        course.id = cl
-        course.system = Mock()
-        course.scope_ids = Mock()
-        course.scope_id.user_id = None
-        course.scope_ids.block_type = u'course'
-        course.scope_ids.def_id = bul
-        course.scope_ids.usage_id = bul
-        course.location = bul
-        course.display_name = u'Course - Run 1'
-
-        self.course_id_string = course_id_string
-        self.cl = cl
-        self.course = course
-
-        email_params = {'registration_url': u'https://localhost:8000/register',  # noqa: E501
-                        'course_about_url': u'https://localhost:8000/courses/course-v1:org+course+run1/about',  # noqa: E501
-                        'site_name': 'localhost:8000',
-                        'course': course,
-                        'is_shib_course': None,
-                        'display_name': u'Course - Run 1',
-                        'auto_enroll': True,
-                        'course_url': u'https://localhost:8000/courses/course-v1:org+course+run1/'}  # noqa: E501
-        self.email_params = email_params
+class EmailEnrollmentTest(MockCourseTestCase):
 
     def test_enrollment_failure(self):
         # Enrolling in a non-existent course (or run) should fail, no

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from edx_shopify.utils import hmac_is_valid, record_order
 from edx_shopify.utils import auto_enroll_email
 from edx_shopify.utils import process_order, process_line_item
 
-from edx_shopify.models import Order
+from edx_shopify.models import Order, OrderItem
 
 from . import JsonPayloadTestCase, MockCourseTestCase
 
@@ -95,7 +95,7 @@ class ProcessLineItemTest(MockCourseTestCase):
                                 get_course_by_id=mock_get_course_by_id,
                                 get_email_params=mock_get_email_params,
                                 enroll_email=mock_enroll_email):
-                process_line_item(order, line_item)
+                order_item = process_line_item(order, line_item)
 
                 # Did we mock-fetch the course with the correct locator?
                 mock_get_course_by_id.assert_called_once_with(self.cl)
@@ -113,6 +113,13 @@ class ProcessLineItemTest(MockCourseTestCase):
                                                           email_students=True,
                                                           email_params=self.email_params,  # noqa: E501
                                                           language=None)
+
+                # Read back the order item
+                order_item.refresh_from_db()
+                self.assertEqual(order_item.order, order)
+                self.assertEqual(order_item.sku, 'course-v1:org+course+run1')
+                self.assertEqual(order_item.email, 'learner@example.com')
+                self.assertEqual(order_item.status, OrderItem.PROCESSED)
 
     def test_invalid_line_item(self):
         order = Order()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,7 +7,6 @@ import hmac
 
 from django.conf import settings
 from django.test import TestCase, Client
-from edx_shopify.models import Order
 
 
 class TestOrderCreation(TestCase):
@@ -39,22 +38,6 @@ class TestOrderCreation(TestCase):
         self.correct_signature = base64.b64encode(correct_hash.digest())
         self.incorrect_signature = base64.b64encode(incorrect_hash.digest())
         self.corrupt_signature = "-%s" % base64.b64encode(correct_hash.digest())[1:]  # noqa: E501
-
-    def test_successful_order_creation(self):
-        response = self.client.post('/shopify/order/create',
-                                    self.raw_payload,
-                                    content_type='application/json',
-                                    HTTP_X_SHOPIFY_HMAC_SHA256=self.correct_signature,  # noqa: E501
-                                    HTTP_X_SHOPIFY_SHOP_DOMAIN='example.com')
-        self.assertEqual(response.status_code, 200)
-
-        order = Order.objects.get(id=self.json_payload['id'])
-        self.assertEqual(order.email,
-                         self.json_payload['customer']['email'])
-        self.assertEqual(order.first_name,
-                         self.json_payload['customer']['first_name'])
-        self.assertEqual(order.last_name,
-                         self.json_payload['customer']['last_name'])
 
     def test_invalid_method_put(self):
         response = self.client.put('/shopify/order/create',

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,29 +1,23 @@
 # -*- coding: utf-8 -*-
-import json
-import os
 import hashlib
 import base64
 import hmac
 
 from django.conf import settings
-from django.test import TestCase, Client
+from django.test import Client
+
+from . import JsonPayloadTestCase
 
 
-class TestOrderCreation(TestCase):
+class TestOrderCreation(JsonPayloadTestCase):
 
     def setUp(self):
+        super(TestOrderCreation, self).setUp()
         # Set enforce_csrf_checks=True here because testing must still
         # work (webhooks are explicitly exempted from CSRF protection)
         self.client = Client(enforce_csrf_checks=True)
 
         conf = settings.WEBHOOK_SETTINGS['edx_shopify']
-
-        # Grab an example payload and make it available to test
-        # methods as a raw string and as a JSON dictionary.
-        payload_file = os.path.join(os.path.dirname(__file__),
-                                    'post.json')
-        self.raw_payload = open(payload_file, 'r').read()
-        self.json_payload = json.loads(self.raw_payload)
 
         # Calculate 3 SHA256 hashes over the payload, which the
         # webhook handler must verify and accept or reject: a correct


### PR DESCRIPTION
- Rather than catching error conditions in various places in `tasks.ProcessOrder.run()`, propagate them and handle them in `on_failure()` instead.
- Configure Travis to run mongodb.
- Fix up test harness with a content store and module store.
- Add tests for enrollment failure (we can't test for enrollment success yet).
- Move methods from tasks.py to utils.py, and add separate test cases.
- Refactor the order processing task using the `shared_task` decorator and success and failure handlers, add tests.